### PR TITLE
If JavaScript is disbled, don't underline the FAQ links. It's confusing.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,9 @@
 <script src="js/jquery-2.1.4.min.js" type="text/javascript"></script>
 <script>
     $(document).ready(function() {
+        $("body.no-js").removeClass("no-js");
+    });
+    $(document).ready(function() {
         $('div.a').hide();
         $('a.q').parent().addClass('answer').click(function (e) {
             e.preventDefault();

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -11,7 +11,7 @@
   <link rel="stylesheet" href="css/solo.css">
 {% include head.html %}
 </head>
-<body>
+<body class="no-js">
   <div class="container">
     <h1><a href="./">{{ site.tag_text }}</a></h1>
     {{ content }}

--- a/css/solo.css
+++ b/css/solo.css
@@ -31,6 +31,10 @@ a:hover, a:focus {
   text-decoration: underline;
 }
 
+.no-js a:not([href]) {
+    text-decoration: none;
+}
+
 h1, h2, h3, h4, h5, h6 {
   font-family: Montserrat, sans-serif;
   margin: 0 0 0.5rem -0.1rem /* align left edge */;


### PR DESCRIPTION
I browse with JS disabled by default, which meant that reading the FAQ
presented me with what looked to be dead links. In fact, these elements
were really just activation points for a JavaScript animation. I found
that to be somewhat confusing sine, again, JS is disabled by default.

This patch fixes the issue by removing the visual indication of a link
on anchors that have no `href` attribute, but retaining the same
behavior for visitors that have JavaScript enabled.
